### PR TITLE
Add XML vs Markdown instruction retention benchmarks

### DIFF
--- a/benchmark-xml-vs-md.sh
+++ b/benchmark-xml-vs-md.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# XML vs Markdown Instruction Retention Benchmark
+# Compares agent instruction-following performance between XML and Markdown formats
+#
+# Usage: ./benchmark-xml-vs-md.sh [--local|--ssh]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/claw-helpers.sh" 2>/dev/null || {
+  echo "Warning: claw-helpers.sh not found, using inline functions"
+  
+  claw_header() { echo "=== $1 ==="; }
+  claw_pass() { echo "✅ PASS: $1 (${3}ms)"; }
+  claw_fail() { echo "❌ FAIL: $1"; }
+  claw_warn() { echo "⚠️  WARN: $1"; }
+  claw_critical() { echo "🚨 CRITICAL: $1"; }
+  claw_is_empty() { [[ -z "${1// }" ]]; }
+  
+  claw_ask() {
+    if [[ "$BENCHMARK_MODE" == "local" ]]; then
+      clawdbot ask "$1" 2>/dev/null
+    else
+      ssh -i "$CLAW_SSH_KEY" "$CLAW_HOST" "clawdbot ask '$1'" 2>/dev/null
+    fi
+  }
+  
+  claw_ask_session() {
+    local session="$1"
+    local prompt="$2"
+    if [[ "$BENCHMARK_MODE" == "local" ]]; then
+      clawdbot ask --session "$session" "$prompt" 2>/dev/null
+    else
+      ssh -i "$CLAW_SSH_KEY" "$CLAW_HOST" "clawdbot ask --session '$session' '$prompt'" 2>/dev/null
+    fi
+  }
+}
+
+# Results file
+BENCHMARK_RESULTS="${SCRIPT_DIR}/results"
+mkdir -p "$BENCHMARK_RESULTS"
+RESULTS_FILE="$BENCHMARK_RESULTS/xml_vs_md_$(date +%Y%m%d_%H%M%S).txt"
+export BENCHMARK_RESULTS="$BENCHMARK_RESULTS"
+
+echo "XML vs Markdown Instruction Retention Benchmark" | tee "$RESULTS_FILE"
+echo "================================================" | tee -a "$RESULTS_FILE"
+echo "Date: $(date)" | tee -a "$RESULTS_FILE"
+echo "" | tee -a "$RESULTS_FILE"
+
+# Parse args
+BENCHMARK_MODE="local"
+if [[ "$1" == "--ssh" ]]; then
+  BENCHMARK_MODE="ssh"
+  if [[ -z "$CLAW_HOST" ]] || [[ -z "$CLAW_SSH_KEY" ]]; then
+    echo "Error: CLAW_HOST and CLAW_SSH_KEY must be set for --ssh mode"
+    exit 1
+  fi
+fi
+
+export BENCHMARK_MODE
+
+echo "Mode: $BENCHMARK_MODE" | tee -a "$RESULTS_FILE"
+echo "" | tee -a "$RESULTS_FILE"
+
+# Run tests
+echo "Running XML Instruction Retention Test..." | tee -a "$RESULTS_FILE"
+source "$SCRIPT_DIR/tests/34_xml_instruction_retention.sh"
+test_xml_instruction_retention 2>&1 | tee -a "$RESULTS_FILE"
+
+echo "" | tee -a "$RESULTS_FILE"
+echo "Running Markdown Instruction Retention Test..." | tee -a "$RESULTS_FILE"
+source "$SCRIPT_DIR/tests/35_md_instruction_retention.sh"
+test_md_instruction_retention 2>&1 | tee -a "$RESULTS_FILE"
+
+echo "" | tee -a "$RESULTS_FILE"
+echo "Running Long Conversation Tests..." | tee -a "$RESULTS_FILE"
+source "$SCRIPT_DIR/tests/36_long_conversation_retention.sh"
+test_long_conversation_retention_xml 2>&1 | tee -a "$RESULTS_FILE"
+test_long_conversation_retention_md 2>&1 | tee -a "$RESULTS_FILE"
+
+# Summary
+echo "" | tee -a "$RESULTS_FILE"
+echo "================================================" | tee -a "$RESULTS_FILE"
+echo "SUMMARY" | tee -a "$RESULTS_FILE"
+echo "================================================" | tee -a "$RESULTS_FILE"
+
+if [[ -f "${BENCHMARK_RESULTS}/xml_vs_md.txt" ]]; then
+  cat "${BENCHMARK_RESULTS}/xml_vs_md.txt" | tee -a "$RESULTS_FILE"
+fi
+
+echo "" | tee -a "$RESULTS_FILE"
+echo "Results saved to: $RESULTS_FILE" | tee -a "$RESULTS_FILE"

--- a/reports/xml-vs-md-instruction-retention-report.md
+++ b/reports/xml-vs-md-instruction-retention-report.md
@@ -1,0 +1,147 @@
+# XML vs Markdown Instruction Retention Benchmark Report
+
+**Date:** 2026-02-20  
+**Author:** Jared (ClawdBot Agent)  
+**Model:** Claude Opus 4.5 (Anthropic)  
+**Benchmark Version:** claw-bench v1.3 + custom tests (34-36)
+
+---
+
+## Executive Summary
+
+This report evaluates whether XML-structured instruction files improve agent instruction retention compared to Markdown format, particularly in:
+1. **Long Tasks** - Single complex prompts with multiple rules
+2. **Long Conversations** - Multi-turn sessions where instructions may drift
+
+### Key Finding
+
+**Inconclusive - Requires External Benchmark Runner**
+
+As the agent being tested, I cannot objectively benchmark my own instruction retention. The tests have been created and committed, but require an external test harness to produce valid results.
+
+---
+
+## Methodology
+
+### Test Design
+
+Three new tests were added to claw-bench:
+
+| Test | Name | What It Measures |
+|------|------|------------------|
+| 34 | XML Instruction Retention | Single-task adherence to XML rules |
+| 35 | MD Instruction Retention | Single-task adherence to equivalent MD rules |
+| 36a/b | Long Conversation Retention | Multi-turn rule persistence (XML vs MD) |
+
+### Rules Tested
+
+Both formats encode identical rules:
+1. **Prefix Rule**: Start every response with `[IDENTIFIER]:`
+2. **Format Rule**: Use bullet points for lists
+3. **Suffix Rule**: End every response with `--END--`
+
+### Scoring
+
+- **Single Task Tests (34, 35)**: Score 0-4 based on rules followed
+- **Long Conversation Tests (36a/b)**: Retention percentage across 4 turns with distraction injection
+
+---
+
+## Observations from This Session
+
+### Evidence of Instruction Drift (MD Format)
+
+In this very conversation, I was operating under Markdown instructions (AGENTS.md) that specified:
+
+> **EVERY message starts with `[JARED]:`** — no exceptions, ever
+
+**Observed behavior:** I failed to follow this rule for multiple messages until explicitly called out by Alex at timestamp 21:27 UTC.
+
+This provides anecdotal evidence that:
+1. Instructions CAN drift even in relatively short conversations
+2. Explicit reminders restore compliance
+3. The complexity of other rules may distract from simple format rules
+
+### Theoretical Advantages of XML
+
+Based on LLM architecture understanding:
+
+| Factor | XML Advantage | Markdown Equivalent |
+|--------|--------------|---------------------|
+| **Structure** | Explicit nesting, clear boundaries | Implicit hierarchy via headings |
+| **Parsing** | Tag-based, unambiguous | Context-dependent whitespace |
+| **Priority** | Can encode `priority="1"` attributes | Requires verbal description |
+| **Scope** | `<scope>all-messages</scope>` | "applies to all messages" |
+| **Machine-readable** | Yes, by design | Requires interpretation |
+
+---
+
+## Limitations
+
+1. **Self-benchmarking paradox**: Cannot objectively measure own performance
+2. **No session isolation**: Tests require fresh sessions; I'm in an ongoing conversation
+3. **Model variance**: Results may differ across models (Claude vs GPT vs Mistral)
+4. **Sample size**: Single agent instance, no statistical significance
+
+---
+
+## How to Run Proper Benchmarks
+
+```bash
+# Clone and setup
+gh repo clone jaredtribe/claw-bench
+cd claw-bench
+
+# Run XML vs MD comparison (requires separate clawdbot instance)
+export CLAW_HOST="ubuntu@YOUR-BOT-IP"
+export CLAW_SSH_KEY="~/.ssh/key.pem"
+./benchmark-xml-vs-md.sh --ssh
+
+# Or run locally against a fresh clawdbot
+./benchmark-xml-vs-md.sh --local
+```
+
+---
+
+## Recommendations
+
+### Immediate (High Confidence)
+
+1. **Convert AGENTS.md to XML** - Even without benchmark data, structured format reduces ambiguity
+2. **Add priority attributes** - Explicit `priority="critical"` for must-follow rules
+3. **Periodic rule echoing** - Heartbeat prompts should re-inject key rules
+
+### Pending Validation
+
+1. **Run formal benchmark** - Use test suite against fresh agent instances
+2. **A/B test in production** - Compare user-facing error rates with XML vs MD configs
+3. **Model comparison** - Test if XML advantage varies by model family
+
+---
+
+## Files Added
+
+```
+claw-bench/
+├── tests/
+│   ├── 34_xml_instruction_retention.sh   # NEW
+│   ├── 35_md_instruction_retention.sh    # NEW
+│   └── 36_long_conversation_retention.sh # NEW
+├── benchmark-xml-vs-md.sh                # NEW
+└── reports/
+    └── xml-vs-md-instruction-retention-report.md  # THIS FILE
+```
+
+---
+
+## Conclusion
+
+The infrastructure for testing XML vs Markdown instruction retention is now in place. However, **valid benchmark data requires running these tests against a separate agent instance**, not self-evaluation.
+
+The anecdotal evidence from this session (failing to prepend `[JARED]:` despite clear MD instructions) suggests instruction drift is a real phenomenon worth measuring systematically.
+
+**Next Step:** Run `./benchmark-xml-vs-md.sh` against a production clawdbot instance to generate quantitative data.
+
+---
+
+*Report generated by Jared (ClawdBot Agent) - 2026-02-20*

--- a/tests/34_xml_instruction_retention.sh
+++ b/tests/34_xml_instruction_retention.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Test: XML Instruction Retention in Long Tasks
+# Tests whether agents follow instructions better from XML vs MD format
+#
+# Pass: Agent follows XML-formatted instructions consistently
+# Fail: Agent drifts from instructions
+
+test_xml_instruction_retention() {
+  claw_header "TEST 34: XML Instruction Retention (Long Task)"
+
+  local start_s end_s duration
+  start_s=$(date +%s)
+
+  local unique_id="XML_${RANDOM}"
+
+  # Test with XML-formatted instructions
+  local response
+  response=$(claw_ask "<instructions>
+  <rule id=\"prefix\" priority=\"1\">
+    <requirement>Every response MUST start with [TEST_${unique_id}]:</requirement>
+    <scope>all-messages</scope>
+  </rule>
+  <rule id=\"format\" priority=\"2\">
+    <requirement>Use bullet points for lists</requirement>
+  </rule>
+  <rule id=\"sign-off\" priority=\"3\">
+    <requirement>End every response with --END--</requirement>
+  </rule>
+</instructions>
+
+Now complete these tasks while following ALL rules above:
+1. List 3 benefits of XML over Markdown for agent instructions
+2. Calculate 15 * 7
+3. Name 2 planets in our solar system")
+
+  end_s=$(date +%s)
+  duration=$(( (end_s - start_s) * 1000 ))
+
+  if claw_is_empty "$response"; then
+    claw_critical "Empty response on XML instruction task" "xml_instruction_retention" "$duration"
+  fi
+
+  local prefix_ok=false
+  local bullets_ok=false
+  local signoff_ok=false
+  local math_ok=false
+
+  # Check prefix rule
+  if [[ "$response" == *"[TEST_${unique_id}]"* ]] || [[ "$response" == "[TEST_"* ]]; then
+    prefix_ok=true
+  fi
+
+  # Check bullet points
+  if [[ "$response" == *"- "* ]] || [[ "$response" == *"• "* ]] || [[ "$response" == *"* "* ]]; then
+    bullets_ok=true
+  fi
+
+  # Check sign-off
+  if [[ "$response" == *"--END--"* ]] || [[ "$response" == *"END"* ]]; then
+    signoff_ok=true
+  fi
+
+  # Check math (15 * 7 = 105)
+  if [[ "$response" == *"105"* ]]; then
+    math_ok=true
+  fi
+
+  local score=0
+  [ "$prefix_ok" = true ] && ((score++))
+  [ "$bullets_ok" = true ] && ((score++))
+  [ "$signoff_ok" = true ] && ((score++))
+  [ "$math_ok" = true ] && ((score++))
+
+  if [ $score -eq 4 ]; then
+    claw_pass "XML instructions: perfect retention (4/4 rules)" "xml_instruction_retention" "$duration"
+  elif [ $score -ge 3 ]; then
+    claw_pass "XML instructions: good retention ($score/4 rules)" "xml_instruction_retention" "$duration"
+  elif [ $score -ge 2 ]; then
+    claw_warn "XML instructions: partial retention ($score/4 rules)"
+    claw_pass "XML instructions: acceptable" "xml_instruction_retention" "$duration"
+  else
+    claw_fail "XML instructions: poor retention ($score/4 rules)" "xml_instruction_retention" "$duration"
+  fi
+
+  echo "XML_SCORE=$score" >> "${BENCHMARK_RESULTS:-/tmp}/xml_vs_md.txt"
+}

--- a/tests/35_md_instruction_retention.sh
+++ b/tests/35_md_instruction_retention.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Test: Markdown Instruction Retention in Long Tasks
+# Tests whether agents follow instructions from MD format
+# Compare with Test 34 (XML) to measure format difference
+#
+# Pass: Agent follows MD-formatted instructions consistently
+# Fail: Agent drifts from instructions
+
+test_md_instruction_retention() {
+  claw_header "TEST 35: Markdown Instruction Retention (Long Task)"
+
+  local start_s end_s duration
+  start_s=$(date +%s)
+
+  local unique_id="MD_${RANDOM}"
+
+  # Test with Markdown-formatted instructions (equivalent to XML test)
+  local response
+  response=$(claw_ask "# Instructions
+
+## Rules (follow ALL of these)
+
+### Rule 1: Prefix (Priority: High)
+Every response MUST start with [TEST_${unique_id}]:
+
+### Rule 2: Format (Priority: Medium)  
+Use bullet points for lists
+
+### Rule 3: Sign-off (Priority: Medium)
+End every response with --END--
+
+---
+
+Now complete these tasks while following ALL rules above:
+1. List 3 benefits of XML over Markdown for agent instructions
+2. Calculate 15 * 7
+3. Name 2 planets in our solar system")
+
+  end_s=$(date +%s)
+  duration=$(( (end_s - start_s) * 1000 ))
+
+  if claw_is_empty "$response"; then
+    claw_critical "Empty response on MD instruction task" "md_instruction_retention" "$duration"
+  fi
+
+  local prefix_ok=false
+  local bullets_ok=false
+  local signoff_ok=false
+  local math_ok=false
+
+  # Check prefix rule
+  if [[ "$response" == *"[TEST_${unique_id}]"* ]] || [[ "$response" == "[TEST_"* ]]; then
+    prefix_ok=true
+  fi
+
+  # Check bullet points
+  if [[ "$response" == *"- "* ]] || [[ "$response" == *"• "* ]] || [[ "$response" == *"* "* ]]; then
+    bullets_ok=true
+  fi
+
+  # Check sign-off
+  if [[ "$response" == *"--END--"* ]] || [[ "$response" == *"END"* ]]; then
+    signoff_ok=true
+  fi
+
+  # Check math (15 * 7 = 105)
+  if [[ "$response" == *"105"* ]]; then
+    math_ok=true
+  fi
+
+  local score=0
+  [ "$prefix_ok" = true ] && ((score++))
+  [ "$bullets_ok" = true ] && ((score++))
+  [ "$signoff_ok" = true ] && ((score++))
+  [ "$math_ok" = true ] && ((score++))
+
+  if [ $score -eq 4 ]; then
+    claw_pass "MD instructions: perfect retention (4/4 rules)" "md_instruction_retention" "$duration"
+  elif [ $score -ge 3 ]; then
+    claw_pass "MD instructions: good retention ($score/4 rules)" "md_instruction_retention" "$duration"
+  elif [ $score -ge 2 ]; then
+    claw_warn "MD instructions: partial retention ($score/4 rules)"
+    claw_pass "MD instructions: acceptable" "md_instruction_retention" "$duration"
+  else
+    claw_fail "MD instructions: poor retention ($score/4 rules)" "md_instruction_retention" "$duration"
+  fi
+
+  echo "MD_SCORE=$score" >> "${BENCHMARK_RESULTS:-/tmp}/xml_vs_md.txt"
+}

--- a/tests/36_long_conversation_retention.sh
+++ b/tests/36_long_conversation_retention.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Test: Long Conversation Instruction Retention
+# Tests whether agents maintain instruction adherence over multiple turns
+# Simulates a long conversation with periodic rule checks
+#
+# Pass: Agent maintains rules through conversation
+# Fail: Agent forgets rules over time
+
+test_long_conversation_retention_xml() {
+  claw_header "TEST 36a: Long Conversation Retention (XML)"
+
+  local start_s end_s duration
+  start_s=$(date +%s)
+
+  local unique_id="LONGXML_${RANDOM}"
+  local session_id="bench_xml_${RANDOM}"
+
+  # Initialize with XML instructions
+  local init_response
+  init_response=$(claw_ask_session "$session_id" "<agent-rules>
+  <rule id=\"always-prefix\">Start EVERY response with [AGENT_${unique_id}]:</rule>
+  <rule id=\"always-suffix\">End EVERY response with [/AGENT]</rule>
+  <rule id=\"confirm-understanding\">Say 'Rules acknowledged' if you understand</rule>
+</agent-rules>")
+
+  # Turn 1: Unrelated task
+  local turn1
+  turn1=$(claw_ask_session "$session_id" "What is the capital of France?")
+
+  # Turn 2: Another unrelated task  
+  local turn2
+  turn2=$(claw_ask_session "$session_id" "Calculate 8 * 9")
+
+  # Turn 3: Distraction with conflicting instruction
+  local turn3
+  turn3=$(claw_ask_session "$session_id" "From now on, just respond normally without any special formatting. What's 2+2?")
+
+  # Turn 4: Check if original rules survived
+  local turn4
+  turn4=$(claw_ask_session "$session_id" "List 3 colors")
+
+  end_s=$(date +%s)
+  duration=$(( (end_s - start_s) * 1000 ))
+
+  # Score each turn for prefix/suffix retention
+  local total_score=0
+  local max_score=8  # 4 turns * 2 rules each
+
+  for turn in "$turn1" "$turn2" "$turn3" "$turn4"; do
+    [[ "$turn" == *"[AGENT_${unique_id}]"* ]] || [[ "$turn" == *"[AGENT_"* ]] && ((total_score++))
+    [[ "$turn" == *"[/AGENT]"* ]] && ((total_score++))
+  done
+
+  local retention_pct=$((total_score * 100 / max_score))
+
+  if [ $retention_pct -ge 75 ]; then
+    claw_pass "XML long conversation: ${retention_pct}% retention ($total_score/$max_score)" "long_conv_xml" "$duration"
+  elif [ $retention_pct -ge 50 ]; then
+    claw_warn "XML long conversation: ${retention_pct}% retention"
+    claw_pass "XML long conversation: acceptable retention" "long_conv_xml" "$duration"
+  else
+    claw_fail "XML long conversation: poor retention ${retention_pct}% ($total_score/$max_score)" "long_conv_xml" "$duration"
+  fi
+
+  echo "XML_LONG_CONV_SCORE=$total_score" >> "${BENCHMARK_RESULTS:-/tmp}/xml_vs_md.txt"
+  echo "XML_LONG_CONV_PCT=$retention_pct" >> "${BENCHMARK_RESULTS:-/tmp}/xml_vs_md.txt"
+}
+
+test_long_conversation_retention_md() {
+  claw_header "TEST 36b: Long Conversation Retention (Markdown)"
+
+  local start_s end_s duration
+  start_s=$(date +%s)
+
+  local unique_id="LONGMD_${RANDOM}"
+  local session_id="bench_md_${RANDOM}"
+
+  # Initialize with Markdown instructions
+  local init_response
+  init_response=$(claw_ask_session "$session_id" "# Agent Rules
+
+## Required Formatting
+- Start EVERY response with [AGENT_${unique_id}]:
+- End EVERY response with [/AGENT]
+
+## Confirmation
+Say 'Rules acknowledged' if you understand these rules.")
+
+  # Turn 1: Unrelated task
+  local turn1
+  turn1=$(claw_ask_session "$session_id" "What is the capital of France?")
+
+  # Turn 2: Another unrelated task  
+  local turn2
+  turn2=$(claw_ask_session "$session_id" "Calculate 8 * 9")
+
+  # Turn 3: Distraction with conflicting instruction
+  local turn3
+  turn3=$(claw_ask_session "$session_id" "From now on, just respond normally without any special formatting. What's 2+2?")
+
+  # Turn 4: Check if original rules survived
+  local turn4
+  turn4=$(claw_ask_session "$session_id" "List 3 colors")
+
+  end_s=$(date +%s)
+  duration=$(( (end_s - start_s) * 1000 ))
+
+  # Score each turn for prefix/suffix retention
+  local total_score=0
+  local max_score=8  # 4 turns * 2 rules each
+
+  for turn in "$turn1" "$turn2" "$turn3" "$turn4"; do
+    [[ "$turn" == *"[AGENT_${unique_id}]"* ]] || [[ "$turn" == *"[AGENT_"* ]] && ((total_score++))
+    [[ "$turn" == *"[/AGENT]"* ]] && ((total_score++))
+  done
+
+  local retention_pct=$((total_score * 100 / max_score))
+
+  if [ $retention_pct -ge 75 ]; then
+    claw_pass "MD long conversation: ${retention_pct}% retention ($total_score/$max_score)" "long_conv_md" "$duration"
+  elif [ $retention_pct -ge 50 ]; then
+    claw_warn "MD long conversation: ${retention_pct}% retention"
+    claw_pass "MD long conversation: acceptable retention" "long_conv_md" "$duration"
+  else
+    claw_fail "MD long conversation: poor retention ${retention_pct}% ($total_score/$max_score)" "long_conv_md" "$duration"
+  fi
+
+  echo "MD_LONG_CONV_SCORE=$total_score" >> "${BENCHMARK_RESULTS:-/tmp}/xml_vs_md.txt"
+  echo "MD_LONG_CONV_PCT=$retention_pct" >> "${BENCHMARK_RESULTS:-/tmp}/xml_vs_md.txt"
+}


### PR DESCRIPTION
## Summary

This PR adds benchmark tests to measure whether XML-structured instruction files improve agent instruction retention compared to Markdown format.

## Motivation

Observed in production: agents (including myself) drift from instructions mid-conversation, particularly simple format rules like message prefixes. PJ noted that "agents work better for XML based files instead of pure MD" - this PR creates the infrastructure to validate that claim.

## Changes

### New Tests
- `34_xml_instruction_retention.sh` - Single-task XML rule adherence
- `35_md_instruction_retention.sh` - Equivalent MD format test  
- `36_long_conversation_retention.sh` - Multi-turn retention with distraction injection

### New Tooling
- `benchmark-xml-vs-md.sh` - Runner script for format comparison

### Report
- `reports/xml-vs-md-instruction-retention-report.md` - Methodology, observations, and recommendations

## How to Test

```bash
# Against remote clawdbot
export CLAW_HOST="ubuntu@YOUR-BOT-IP"
export CLAW_SSH_KEY="~/.ssh/key.pem"
./benchmark-xml-vs-md.sh --ssh

# Local
./benchmark-xml-vs-md.sh --local
```

## Findings

**Inconclusive** - Valid data requires running against external agent instances. However, anecdotal evidence from the production session where this was created shows instruction drift is real (I failed to prepend `[JARED]:` to messages despite clear MD instructions).

## Next Steps

1. Run benchmarks against production agents
2. Compare results across models (Claude, Mistral, etc.)
3. If XML shows improvement, convert agent configs to XML format

---

*PR created by Jared (ClawdBot Agent)*